### PR TITLE
Further changes to move the remaining hard-coded HCA field names to config; plus minor simplifications.

### DIFF
--- a/hca2mtab.py
+++ b/hca2mtab.py
@@ -24,7 +24,7 @@ process_name = 'hca2mtab'
 # - 'dryrun' lists what project uuids would be retrieved and what gxa accessions they would be assigned to, and
 # - 'prod' is the norma production run
 # data_dir - directory in which the generated magetab files should be placed
-def convert_hca_json_to_magetab(mode, data_dir, email_recipients, new_only = True):
+def convert_hca_json_to_magetab(mode, data_dir, email_from, email_recipients, new_only = True):
     # Retrieve the HCA Json to MAGETAB translation config
     config = utils.get_config(process_name)
     idf_config = utils.get_val(config, 'idf')
@@ -443,8 +443,9 @@ if __name__ == '__main__':
 
     mode = sys.argv[1]
     data_dir = sys.argv[2]
-    email_recipients = sys.argv[3]
+    email_from = sys.argv[3]
+    email_recipients = sys.argv[4]
     try:
-        convert_hca_json_to_magetab(mode, data_dir, email_recipients, True)
+        convert_hca_json_to_magetab(mode, data_dir, email_from, email_recipients, True)
     except utils.HCA2MagetabTranslationError as exc:
         utils.email_report("%s error" % process_name, "%s has crashed with the following error: %s" % (process_name, str(exc)), email_recipients)

--- a/hca2mtab.py
+++ b/hca2mtab.py
@@ -99,24 +99,8 @@ def convert_hca_json_to_magetab(mode, data_dir, email_recipients, new_only = Tru
             project_bundle_uuids = (project_uuid, bundle_uuid)
             # Get all relevant HCA objcts for bundle_uuid into hca_json dict
             hca_json = {}
-            # Iterate over (file_uuid, file_name) tuples corresponding to bundle_uuid
-            for (file_uuid, file_name) in bundle2metadata_files[bundle_uuid]:
-                file_type = file_name.split('.')[0]
-                # Retrieve the json for file_uuid from cache if it's there; otherwise retrieve it from HCA DCC and add to the cache
-                if file_uuid not in hca_json_cache.keys():
-                    file_json_url = '%s/files/%s?replica=aws' % (hca_api_url_root, file_uuid)
-                    logger.debug('Study uuid: %s ; bundle uuid: %s ; Accession: %s - About to retrieve file (of type: %s) : %s ' % (project_uuid, bundle_uuid, accession, file_type, file_json_url))
-                    row_data = utils.get_remote_json(file_json_url, logger)[0]
-                    if not re.search(r"^sequence\_file\_\d+$|^process\_\d+$|^links$", file_name):
-                        # Don't cache sequence file, process or links json files - as these typically change for every bundle,
-                        # thus caching them would be a waste of memory
-                        hca_json_cache[file_uuid] = row_data
-                    # Store retrieved json in hca_json[file_type]
-                    hca_json[file_type] = row_data
-                else:
-                    # json is in cache - retrieve from there
-                    hca_json[file_type] = hca_json_cache[file_uuid]
-                logger.debug("%s : %s --> %s" % (accession, file_name, hca_json[file_type]))
+            # Retrieve into hca_json/hca_json_cache all the json files for bundle_uuid
+            utils.retrieve_hca_json_for_bundle(accession, bundle2metadata_files, project_bundle_uuids, hca_json, hca_json_cache, hca_api_url_root, config, logger)
             bundle_cnt += 1
             if bundle_cnt % 50 == 0:
                 time_end = utils.unix_time_millis(datetime.now())
@@ -147,7 +131,7 @@ def convert_hca_json_to_magetab(mode, data_dir, email_recipients, new_only = Tru
             # Set of indexes of sdrf columns with non-empty sdrf columns for the current bundle_uuid
             indexes_of_non_empty_sdrf_columns = set([])
             # Output one SDRF row per each sequence file in the bundle
-            for datafile_key in [x for x in hca_json.keys() if re.search(r"^sequence\_file\_\d+$", x)]:
+            for datafile_key in [x for x in hca_json.keys() if re.search(r"" + utils.get_val(config, 'hca_sequence_file_regex'), x)]:
                 sdrf_column_headers = []
                 
                 current_row = []
@@ -178,7 +162,7 @@ def convert_hca_json_to_magetab(mode, data_dir, email_recipients, new_only = Tru
                             # headers: 'Protocol REF\tProtocol REF\tProtocol REF'
                             protocol_ids = ','.join([ x[0] for x in list(protocol_type2protocols_in_bundle[protocol_type]) ])
                             utils.add_to_row(indexes_of_non_empty_sdrf_columns, sdrf_column_headers, magetab_label, protocol_ids, current_row, characteristic_values, config)
-                        elif len(hca_path) > 0 and re.search(r"\_protocol$", hca_path[0]):
+                        elif len(hca_path) > 0 and re.search(r"" + utils.get_val(config, 'hca_protocol_schema_regex'), hca_path[0]):
                             protocol_type = hca_path[0]
                             # Special handling/parsing - for a given protocol_type, various protocol-related information needs to be collected from potentially multiple json files
                             values = set([])
@@ -283,7 +267,7 @@ def convert_hca_json_to_magetab(mode, data_dir, email_recipients, new_only = Tru
                 technology2factor2characteristic_colnum[technology][factor] = technology2sdrf_column_headers[technology].index('Source Name')
 
         # For each technology, write out the generated SDRF file.
-        # N.B. IF the HCA project is multi-technology, append the technology label to the of the file name the sdrf file
+        # N.B. IF the HCA project is multi-technology, append the technology label to the end of the sdrf file name
         multi_technology_hca_project = len(technologies_found) > 1
         for technology in technologies_found:
             sdrf_file_name = "%s.sdrf.txt" % accession
@@ -355,14 +339,14 @@ def convert_hca_json_to_magetab(mode, data_dir, email_recipients, new_only = Tru
                         elif magetab_label == 'Comment[SecondaryAccession]':
                             # Special handling - secondary accessions
                             secondary_accessions = OrderedSet([])
-                            for label in 'geo_series', 'insdc_study':
-                                if label in list(hca_json['project_0'].keys()):
-                                    secondary_accessions.add(hca_json['project_0'][label])
-                            # The string fields 'geo_series', 'insdc_study' will soon be replaced with arrays: 'geo_series_accessions' and 'insdc_study_accessions' respectively - hence the loop below
-                            # c.f. https://github.com/HumanCellAtlas/metadata-schema/blob/master/json_schema/type/project/project.json
-                            for label in 'geo_series_accessions', 'insdc_study_accessions':
-                                if label in list(hca_json['project_0'].keys()):
-                                    for secondary_accession in hca_json['project_0'][label]:
+                            for label in utils.get_val(config, 'hca_old_secondary_accessions_labels'):
+                                hca_project_json = hca_json[utils.get_val(config, 'hca_project_json_file_name')]
+                                if label in list(hca_project_json.keys()):
+                                    secondary_accessions.add(hca_project_json[label])
+                            # For the reason for the loop below see a comment near hca_old_secondary_accessions_labels in hca2mtab.yml
+                            for label in utils.get_val(config, 'hca_new_secondary_accessions_labels'):
+                                if label in list(hca_project_json.keys()):
+                                    for secondary_accession in hca_project_json[label]:
                                         secondary_accessions.add(secondary_accession)
                             # Now append the HCA study uuid
                             secondary_accessions.add(project_uuid)
@@ -441,12 +425,12 @@ def convert_hca_json_to_magetab(mode, data_dir, email_recipients, new_only = Tru
                             if magetab_label == 'Investigation Title':
                                 imported_experiments.append("%s (%s - %d bundles): %s" % (accession, technology, len(bundle2metadata_files.keys()), value))
                     else:
+                        # hca_path is not a list
                         csvwriter.writerow(line_item)
         time_end = utils.unix_time_millis(datetime.now())
         duration = (time_end - time_start)/1000/60
         logger.info("Processing HCA study uuid: %s for gxa accession: %s took %d mins" % (project_uuid, accession, duration))
     if imported_experiments:
-        # Email to email_recipients a report on which experiments were imported from HCA DCC in this run
         utils.email_report("New experiments imported from HCA DCC", '\n'.join(imported_experiments), email_recipients)
 
 if __name__ == '__main__':

--- a/hca2mtab.yml
+++ b/hca2mtab.yml
@@ -212,6 +212,31 @@ notfound: 'NOTFOUND'
 curate: 'CURATE'
 protocol_types : ['differentiation_protocol', 'dissociation_protocol', 'enrichment_protocol', 'library_preparation_protocol', 'sequencing_protocol']
 test_max_bundles: 1
+# Don't cache sequence file, process or links json files - as these typically change for every bundle, thus caching them would be a waste of memory
+hca_json_files_excluded_from_cache_regex: '^sequence\_file\_\d+$|^process\_\d+$|^links$'
+# Various HCA json schema fields used throughout the code:
+hca_sequence_file_regex: '^sequence\_file\_\d+$'
+hca_analysis_file_regex: 'analysis_file_\w+\.json$'
+hca_protocol_schema_regex: '\_protocol$'
+hca_project_json_file_name: "project_0"
+# The string fields 'geo_series', 'insdc_study' have been replaced with arrays: 'geo_series_accessions' and 'insdc_study_accessions' respectively
+# c.f. https://github.com/HumanCellAtlas/metadata-schema/blob/master/json_schema/type/project/project.json
+# but that migration is not reflected in https://github.com/HumanCellAtlas/metadata-schema/blob/master/json_schema/property_migrations.json - hence the explicit config below
+hca_old_secondary_accessions_labels: ['geo_series', 'insdc_study']
+hca_new_secondary_accessions_labels: ['geo_series_accessions', 'insdc_study_accessions']
+hca_schema_version_field_name: "describedBy"
+# The string field 'array_express_investigation' has been replaced with an array field: 'array_express_accessions'
+# c.f. https://github.com/HumanCellAtlas/metadata-schema/blob/master/json_schema/type/project/project.json
+# but that migration is not reflected in https://github.com/HumanCellAtlas/metadata-schema/blob/master/json_schema/property_migrations.json - hence the explicit config below
+hca_old_arrayexpress_label: "array_express_investigation"
+hca_new_arrayexpress_label: "array_express_accessions"
+hca_supplementary_links_label: "supplementary_links"
+hca_project_uuid_elasticsearch_path: "files.project_json.provenance.document_id"
+hca_project_json_path: ['metadata', 'files', 'project_json']
+hca_project_uuid_path: ['provenance', 'document_id']
+hca_project_title_path: ['project_core', 'project_title']
+hca_file_json_path: ['metadata', 'manifest', 'files']
+hca_file_json_name_path: ['name']
 
 cv_translate:
   'Characteristics[organism status]':

--- a/hca2mtab.yml
+++ b/hca2mtab.yml
@@ -238,6 +238,11 @@ hca_project_title_path: ['project_core', 'project_title']
 hca_file_json_path: ['metadata', 'manifest', 'files']
 hca_file_json_name_path: ['name']
 
+# The above config refers to json files of the following HCA schemas with _0 postfix explicitly, and thus follows an implicit assumption that 
+# for a single bundle only one json file exists per schema in the list below. This list is used by the code to test data retrieved from HCA and
+# report a warning (TODO: should be error) if that assumption is broken.
+hca_schemas_with_one_json_per_bundle_expected: ['cell_line', 'cell_suspension', 'donor_organism', 'project', 'specimen_from_organism']
+
 cv_translate:
   'Characteristics[organism status]':
       'no' : 'dead'

--- a/utils.py
+++ b/utils.py
@@ -456,10 +456,10 @@ def expand_protocol_columns(row, headers, protocol_type2num_protocols, logger):
         col_idx += 1
 
 # Email report on all experiments imported from HCA DCC        
-def email_report(body, subject, email_recipients):
+def email_report(body, subject, from, email_recipients):
     msg = MIMEText(body, "plain", "utf-8")
     msg['Subject'] = subject
-    msg['From'] = "fg_atlas@ebi.ac.uk"
+    msg['From'] = from
     msg['To'] = email_recipients
 
     for attempt in range(MAXIMUM_NUMBER_OF_EMAIL_ATTEMPTS):


### PR DESCRIPTION
1. Removed overloaded (and superfluous) definition of email_report method; 2. Move all HCA field names to config; 3. Minor code simplifications