### PR TITLE
1. Encapsulated interface to HCA (project, bundle and json retrieval)…

### DIFF
--- a/hca2mtab.yml
+++ b/hca2mtab.yml
@@ -5,21 +5,21 @@ idf:
   - - 'MAGE-TAB Version'
     - '1.1'
   - - 'Investigation Title'
-    - ['project_0', 'project_core', 'project_title']
+    - ['project', 'project_core', 'project_title']
   - - 'Comment[Submitted Name]'
-    - ['project_0', 'project_core', 'project_short_name']
+    - ['project', 'project_core', 'project_short_name']
   - - 'Experiment Description'
-    - ['project_0', 'project_core', 'project_description']
+    - ['project', 'project_core', 'project_description']
 # Public Release date - special parsing in code
   - - 'Public Release Date'
-    - ['project_0', 'provenance', 'submission_date']
+    - ['project', 'provenance', 'submission_date']
 # Contributors - special parsing in code
   - - ['Person Last Name', 'Person First Name', 'Person Mid Initials', 'Person Email', 'Person Affiliation', 'Person Address']
-    - ['project_0', 'contributors']
+    - ['project', 'contributors']
 # As HCA doesn't identify submitters, the first contributor will be identified as a submitter be default
   - - 'Person Roles'
     - 'submitter'
-# Protocols - special handling in code
+# Protocols - special handling in code - c.f. hca_protocol_*_path fields below
   - - ['Protocol Name', 'Protocol Description', 'Protocol Type']
     - []
 # References - special handling in code (spaces converted to tabs)
@@ -29,7 +29,7 @@ idf:
     - ['http://www.ebi.ac.uk/efo/efo.owl', 'http://www.ebi.ac.uk/arrayexpress/']
 # Publications - - special parsing in code
   - - ['Publication Title', 'Publication Author List', 'PubMed ID', 'Publication DOI']
-    - ['project_0', 'publications']
+    - ['project', 'publications']
 # Experiment Type
   - - 'Comment[AEExperimentType]'
     - 'RNA-seq of coding RNA from single cells'
@@ -62,74 +62,74 @@ sdrf:
 # According for Silvie, this should work fine for Smart-seq2 (each well contains a cell that is considered a single biological replicate)
 # When we come to processing 10x experiments, there is a concept of single (multi-cell) biological sample that is later (e.g. FACS-)separated into
 # individual cells. We will then need to find out where in HCA json an id, unique to the above multi-cell sample is stored, and take it from there.
-    - ['cell_suspension_0', 'biomaterial_core', 'biomaterial_id']
-# HCA bundle uuid - special handling - assign the uuid of the current bundle
-  - - 'Comment[HCA bundle uuid]'
+    - ['cell_suspension', 'biomaterial_core', 'biomaterial_id']
+# HCA bundle url - special handling - assign the url (includes uuid + version) of the current bundle
+  - - 'Comment[HCA bundle url]'
     - []
   - - 'Comment[HCA file uuid]'
     - ['provenance','document_id']    
   - - 'Comment[Sample_description]'
-    - ['specimen_from_organism_0', 'biomaterial_core', 'biomaterial_description']
+    - ['specimen_from_organism', 'biomaterial_core', 'biomaterial_description']
   - - 'Comment[biomaterial name]'
-    - ['specimen_from_organism_0', 'biomaterial_core', 'biomaterial_name']
+    - ['specimen_from_organism', 'biomaterial_core', 'biomaterial_name']
   - - 'Characteristics[immunophenotype]'
     - ['enrichment_protocol', 'markers']
   - - 'Comment[plate id]'
-    - ['cell_suspension_0', 'plate_based_sequencing', 'plate_id']
+    - ['cell_suspension', 'plate_based_sequencing', 'plate_id']
   - - 'Comment [well]'
-    - ['cell_suspension_0', 'plate_based_sequencing', 'well_id']
+    - ['cell_suspension', 'plate_based_sequencing', 'well_id']
   - - 'Characteristics[age]'
-    - ['donor_organism_0', 'organism_age']
+    - ['donor_organism', 'organism_age']
   - - 'Unit [time unit]'
-    - ['donor_organism_0', 'organism_age_unit', 'text']
+    - ['donor_organism', 'organism_age_unit', 'text']
   - - 'Characteristics[biosource provider]'
-    - ['specimen_from_organism_0', 'purchased_specimen', 'manufacturer']
+    - ['specimen_from_organism', 'purchased_specimen', 'manufacturer']
   - - 'Characteristics[body mass index]'
-    - ['donor_organism_0', 'human_specific', 'body_mass_index']
+    - ['donor_organism', 'human_specific', 'body_mass_index']
   - - 'Unit[concentration unit]'
     - ''
   - - 'Characteristics[cause of death]'
-    - ['donor_organism_0', 'death', 'cause_of_death']
+    - ['donor_organism', 'death', 'cause_of_death']
   - - 'Characteristics[cell line]'
-    - ['cell_line_0', 'biomaterial_core', 'biomaterial_name']
+    - ['cell_line', 'biomaterial_core', 'biomaterial_name']
   - - 'Characteristics[cell subtype surface markers]'
     - ['enrichment_protocol', 'markers']
   - - 'Characteristics[cell subtype]'
-    - ['cell_suspension_0', 'selected_cell_type']
+    - ['cell_suspension', 'selected_cell_type']
   - - 'Characteristics[cell type]'
-    - ['cell_line_0', 'cell_type', 'text']
+    - ['cell_line', 'cell_type', 'text']
   - - 'Characteristics[clinical information]'
-    - ['donor_organism_0', 'medical_history', 'test_results']
+    - ['donor_organism', 'medical_history', 'test_results']
   - - 'Characteristics[disease]'
-    - ['donor_organism_0', 'diseases']
+    - ['donor_organism', 'diseases']
   - - 'Characteristics[ethnic group]'
-    - ['donor_organism_0', 'human_specific', 'ethnicity']
+    - ['donor_organism', 'human_specific', 'ethnicity']
   - - 'Characteristics[genotype]'
-    - ['(specimen\_from\_organism|cell\_suspension|cell\_line|donor\_organism)\_0', 'biomaterial_core', 'genotype']
+    - ['(specimen\_from\_organism|cell\_suspension|cell\_line|donor\_organism)', 'biomaterial_core', 'genotype']
   - - 'Characteristics[geographical location]'
-    - ['process\_\d', 'process_core', 'process_location']
+    - ['process', 'process_core', 'process_location']
   - - 'Characteristics[individual]'
-    - ['donor_organism_0', 'biomaterial_core', 'biomaterial_id']
+    - ['donor_organism', 'biomaterial_core', 'biomaterial_id']
   - - 'Characteristics[developmental stage]'
-    - ['donor_organism_0', 'development_stage', 'text']
+    - ['donor_organism', 'development_stage', 'text']
   - - 'Characteristics[organism part]'
-    - ['specimen_from_organism_0', 'organ', 'text']
+    - ['specimen_from_organism', 'organ', 'text']
   - - 'Characteristics[organism status]'
-    - ['donor_organism_0', 'is_living']
+    - ['donor_organism', 'is_living']
   - - 'Characteristics[organism]'
-    - ['specimen_from_organism_0', 'genus_species']
+    - ['specimen_from_organism', 'genus_species']
   - - 'Characteristics[phenotype]'
     - ''
   - - 'Characteristics[sampling site]'
     - ''
   - - 'Characteristics[sex]'
-    - ['donor_organism_0', 'sex']
+    - ['donor_organism', 'sex']
   - - 'Characteristics[single cell quality]'
-    - ['cell_suspension_0', 'plate_based_sequencing', 'cell_quality']
+    - ['cell_suspension', 'plate_based_sequencing', 'cell_quality']
   - - 'Characteristics[strain]'
-    - ['donor_organism_0', 'mouse_specific', 'strain']
+    - ['donor_organism', 'mouse_specific', 'strain']
   - - 'Characteristics[submitted single cell quality]'
-    - ['cell_suspension_0', 'plate_based_sequencing', 'cell_quality']
+    - ['cell_suspension', 'plate_based_sequencing', 'cell_quality']
   - - 'Material Type'
     - 'cell'
 # Protocols - special handling in code
@@ -145,7 +145,7 @@ sdrf:
   - - 'Protocol REF'
     - ['library_preparation_protocol']
   - - 'Extract Name'
-    - ['cell_suspension_0', 'biomaterial_core', 'biomaterial_id']  
+    - ['cell_suspension', 'biomaterial_core', 'biomaterial_id']
   - - 'Comment[single cell isolation]'
     - ['enrichment_protocol', 'enrichment_method', 'text']
   - - 'Comment[input molecule]'
@@ -194,7 +194,7 @@ sdrf:
   - - 'Protocol REF'
     - ['sequencing_protocol']
   - - 'Assay Name'
-    - ['cell_suspension_0', 'biomaterial_core', 'biomaterial_id']
+    - ['cell_suspension', 'biomaterial_core', 'biomaterial_id']
   - - 'Comment[technical replicate group]'
     - ['technical_replicate_group']
   - - 'Technology Type'
@@ -211,36 +211,42 @@ hca_api_url_root: 'https://dss.data.humancellatlas.org/v1'
 notfound: 'NOTFOUND'
 curate: 'CURATE'
 protocol_types : ['differentiation_protocol', 'dissociation_protocol', 'enrichment_protocol', 'library_preparation_protocol', 'sequencing_protocol']
-test_max_bundles: 1
-# Don't cache sequence file, process or links json files - as these typically change for every bundle, thus caching them would be a waste of memory
-hca_json_files_excluded_from_cache_regex: '^sequence\_file\_\d+$|^process\_\d+$|^links$'
+test_max_bundles: 500
 # Various HCA json schema fields used throughout the code:
-hca_sequence_file_regex: '^sequence\_file\_\d+$'
-hca_analysis_file_regex: 'analysis_file_\w+\.json$'
+hca_sequence_file: 'sequence_file'
+hca_analysis_file_regex: 'analysis_file'
 hca_protocol_schema_regex: '\_protocol$'
-hca_project_json_file_name: "project_0"
 # The string fields 'geo_series', 'insdc_study' have been replaced with arrays: 'geo_series_accessions' and 'insdc_study_accessions' respectively
 # c.f. https://github.com/HumanCellAtlas/metadata-schema/blob/master/json_schema/type/project/project.json
 # but that migration is not reflected in https://github.com/HumanCellAtlas/metadata-schema/blob/master/json_schema/property_migrations.json - hence the explicit config below
 hca_old_secondary_accessions_labels: ['geo_series', 'insdc_study']
 hca_new_secondary_accessions_labels: ['geo_series_accessions', 'insdc_study_accessions']
-hca_schema_version_field_name: "describedBy"
+hca_schema_version_field_name: 'describedBy'
 # The string field 'array_express_investigation' has been replaced with an array field: 'array_express_accessions'
 # c.f. https://github.com/HumanCellAtlas/metadata-schema/blob/master/json_schema/type/project/project.json
 # but that migration is not reflected in https://github.com/HumanCellAtlas/metadata-schema/blob/master/json_schema/property_migrations.json - hence the explicit config below
-hca_old_arrayexpress_label: "array_express_investigation"
-hca_new_arrayexpress_label: "array_express_accessions"
-hca_supplementary_links_label: "supplementary_links"
-hca_project_uuid_elasticsearch_path: "files.project_json.provenance.document_id"
-hca_project_json_path: ['metadata', 'files', 'project_json']
+hca_old_arrayexpress_label: 'array_express_investigation'
+hca_new_arrayexpress_label: 'array_express_accessions'
+hca_supplementary_links_label: 'supplementary_links'
+hca_project: 'project'
+hca_project_json: ['project_json']
+hca_files_path: ['metadata', 'files']
+hca_bundle_url: ['bundle_url']
 hca_project_uuid_path: ['provenance', 'document_id']
 hca_project_title_path: ['project_core', 'project_title']
 hca_file_json_path: ['metadata', 'manifest', 'files']
 hca_file_json_name_path: ['name']
+hca_protocol_name_path: ['protocol_core', 'protocol_id']
+hca_protocol_description_path: ['protocol_core', 'protocol_description']
+hca_protocol_type_path: ['protocol_core', 'protocol_name']
+hca_publication_title_path: ['publication_title']
+hca_publication_authors_path: ['authors']
+hca_publication_pmid_path: ['pmid']
+hca_publication_doi_path: ['doi']
 
 # The above config refers to json files of the following HCA schemas with _0 postfix explicitly, and thus follows an implicit assumption that 
 # for a single bundle only one json file exists per schema in the list below. This list is used by the code to test data retrieved from HCA and
-# report a warning (TODO: should be error) if that assumption is broken.
+# report a warning if that assumption is broken.
 hca_schemas_with_one_json_per_bundle_expected: ['cell_line', 'cell_suspension', 'donor_organism', 'project', 'specimen_from_organism']
 
 cv_translate:

--- a/hcadam.py
+++ b/hcadam.py
@@ -1,0 +1,234 @@
+# -*- coding: utf-8 -*-
+# Filename: hcadam.py
+
+# A data access module to HCA DCC - used for HCA project data discovery and json content retrieval
+
+import requests, requests.packages.urllib3.util.retry
+import re
+import utils
+import json
+from datetime import datetime
+from orderedset import OrderedSet
+
+# Data retrieval from HCA error class
+class HCARetrievalError(Exception):
+    pass
+
+# Cache of all json retrieved from HCA - to avoid repeating search queries
+# Structure: project_uuid -> bundle_url -> file_type -> list of json objects
+hca_json_cache = {}
+
+# For HTTP semantics of re-try logic required see: https://dss.integration.data.humancellatlas.org/
+class RetryPolicy(requests.packages.urllib3.util.retry.Retry):
+    def __init__(self, retry_after_status_codes={301}, **kwargs):
+        super(RetryPolicy, self).__init__(**kwargs)
+        self.RETRY_AFTER_STATUS_CODES = frozenset(retry_after_status_codes | requests.packages.urllib3.util.retry.Retry.RETRY_AFTER_STATUS_CODES)
+
+retry_policy = RetryPolicy(read=5, status=5, status_forcelist=frozenset({500, 502, 503, 504}))
+s = requests.Session()
+a = requests.adapters.HTTPAdapter(max_retries=retry_policy)
+s.mount('https://', a)
+
+# Retrieve json from url via method (passing data in the call, if method == 'post')
+# Returns a tuple: (<result (json)>, <returned headers dict (for 'post' only)>)
+def get_remote_json(url, logger, method = 'get', data = None):
+    result = None
+    headers = None
+    err_msg = None
+    try:
+        if method == 'get':
+            r = s.get(url)
+        elif method == 'post':
+            r = s.post(url, data = json.dumps(data), headers = { "Accept" : "application/json", "Content-Type" : "application/json" })
+        else:
+            err_msg = 'Unknown HTTP request method: "' + url + '" : ' + method
+        result = json.loads(r.text)
+        headers = r.headers
+    except requests.HTTPError as e:
+        err_msg = 'HTTPError when retrieving url: "' + url + '" : ' + str(e.code)
+        logger.error(err_msg)
+    except requests.ConnectionError as e:
+        err_msg = 'ConnectionError when retrieving url: "' + url + '" : ' + str(e.reason)
+        logger.error(err_msg)
+    if err_msg:
+        raise HCARetrievalError(err_msg)
+    return (result, headers)
+
+# Retrieve the list of unique project uuids, corresponding to all HCA projects of type: technology
+def get_hca_projects_for_technology(hca_api_url_root, technology, ncbi_taxon_id, already_imported_project_uuids, config, mode, logger):
+    logger.info("About to retrieve HCA projects and their json content for technology: %s ncbi_taxon_id: %d" % (technology, ncbi_taxon_id))
+    time_start = utils.unix_time_millis(datetime.now())
+    project_uuids = set([])
+    smart_regex = re.compile('smart-.*$')
+    tenxV2_regex = re.compile('10xV2')
+    if smart_regex.match(technology):
+        data = { "es_query": {
+                     "query": {
+                         "bool": {
+                             "must": [
+                                 # Smart - seq2
+                                 { "match": { "files.library_preparation_protocol_json.library_construction_approach.ontology": "EFO:0008931" } },
+                                 { "match": { "files.donor_organism_json.biomaterial_core.ncbi_taxon_id": ncbi_taxon_id } }
+                             ],
+                             "should": [
+                                 # fluorescence - activated cell sorting
+                                 { "match": { "files.dissociation_protocol_json.dissociation_method.ontology": "EFO:0009108" } },
+                                 # enzymatic dissociation
+                                 { "match": { "files.dissociation_protocol_json.dissociation_method.ontology": "EFO:0009128"}},
+                                 { "match": { "files.dissociation_protocol_json.dissociation_method.text": "mouth pipette" } }
+                             ], "must_not": [
+                                 { "match": { "files.analysis_process_json.process_type.text": "analysis" } },
+                                 { "range": { "files.donor_organism_json.biomaterial_core.ncbi_taxon_id": { "lt": ncbi_taxon_id } } },
+                                 { "range": { "files.donor_organism_json.biomaterial_core.ncbi_taxon_id": { "gt": ncbi_taxon_id } } }
+                             ] } } } }
+    elif tenxV2_regex.match(technology):
+        data = { "es_query": {
+                     "query": {
+                         "bool": {
+                             "must": [
+                                 # 10X v2 sequencing
+                                 # TODO: what is the EFO number for 10xV1* and 10xV3?
+                                 { "match": { "files.library_preparation_protocol_json.library_construction_approach.ontology": "EFO:0009310" } },
+                                 { "match": { "files.donor_organism_json.biomaterial_core.ncbi_taxon_id": ncbi_taxon_id } }
+                             ],
+                             "must_not": [
+                                 { "match": { "files.analysis_process_json.process_type.text": "analysis" } },
+                                 { "range": { "files.donor_organism_json.biomaterial_core.ncbi_taxon_id": { "lt": ncbi_taxon_id } } },
+                                 { "range": { "files.donor_organism_json.biomaterial_core.ncbi_taxon_id": { "gt": ncbi_taxon_id } } }
+                             ] } } } }
+    else:
+        raise HCARetrievalError('Unknown technology: %s' % technology)
+    # Page size = 10 appears to be the maximum currently allowed
+    url = '%s/%s' % (hca_api_url_root, 'search?output_format=raw&replica=aws&per_page=10')
+    bundle_cnt = 0
+    json_files_cnt = 0
+    while url:
+        (json, headers) = get_remote_json(url, logger, 'post', data)
+        if 'results' not in json:
+            logger.info("No HCA projects were retrieved for technology: %s and ncbi_taxon_id: %d" % (technology, ncbi_taxon_id))
+            break
+        for bundle in json['results']:
+            project_json_path = utils.get_val(config, 'hca_files_path') + utils.get_val(config, 'hca_project_json')
+            project_json = get_hca_structure_for_path(project_json_path, bundle)[0]
+            project_title = utils.get_hca_value(utils.get_val(config, 'hca_project_title_path'), project_json, logger, config, True)
+            if re.search('Test *$', project_title):
+                # Skip test data sets
+                continue
+            project_uuid = utils.get_hca_value(utils.get_val(config, 'hca_project_uuid_path'), project_json, logger, config, True)
+            if project_uuid not in already_imported_project_uuids:
+                # In new_only mode already_imported_project_uuids may not be empty - we only include project_uuids (and cache their json)
+                # if they have not been imported already.
+                project_uuids.add(project_uuid)
+                json_files_cnt += add_bundle_to_json_cache(bundle, project_uuid, config, logger)
+        bundle_cnt += 10
+        if mode == 'test' and bundle_cnt >= utils.get_val(config, 'test_max_bundles'):
+            break
+        if bundle_cnt % 500 == 0:
+            print("%d bundles retrieved (projects so far: %d)" % (bundle_cnt, len(project_uuids)), flush = True)
+        url = get_api_url_for_next_page(headers)
+    time_end = utils.unix_time_millis(datetime.now())
+    duration = (time_end - time_start) / 1000 / 60
+    logger.info("Populating json cache for technology %s ncbi_taxon_id %d took: %d mins (%d bundles; %d json objects)" % (technology, ncbi_taxon_id, duration, bundle_cnt, json_files_cnt))
+    return project_uuids
+
+# Return the url for the next page of results - having extract it via 'Link' key from dict: headers (itself return by the previous api call)
+def get_api_url_for_next_page(headers):
+    url = None
+    if 'Link' in headers.keys() and re.search(r"rel=\"next\"$", headers['Link']):
+        m = re.search(r'^.*\<(https.*?)\>.*$', headers['Link'])
+        if m:
+            url = m.group(1)
+    return url
+
+# Retrieve the set of unique project uuids, corresponding to all smart-seq2 and 10x projects in HCA.
+def get_hca_project_uuid_to_import(hca_api_url_root, config, mode, already_imported_project_uuids, logger):
+    project_uuids = set([])
+    for technology in utils.get_val(config, 'technology_mtab2hca').keys():
+        for ncbi_taxon_id in [9606, 10090]:
+            # human and mouse
+            project_uuids = project_uuids.union(get_hca_projects_for_technology(hca_api_url_root, technology, ncbi_taxon_id, already_imported_project_uuids, config, mode, logger))
+    for project_uuid in project_uuids:
+        logger.info("Populated json cache for %s with %d bundles" % (project_uuid, len(list(hca_json_cache[project_uuid].keys()))))
+    return project_uuids
+
+# Populate hca_json_cache with all the json objects in bundle (within project_uuid); returns number of json files cached
+def add_bundle_to_json_cache(bundle, project_uuid, config, logger):
+    json_files_cnt = 0
+    if project_uuid not in hca_json_cache:
+        hca_json_cache[project_uuid] = {}
+    hca_files_path = utils.get_val(config, 'hca_files_path')
+    bundle_url_schema_path = utils.get_val(config, 'hca_bundle_url')
+    bundle_url = utils.get_hca_value(bundle_url_schema_path, bundle, logger, config, True)
+    if bundle_url in hca_json_cache[project_uuid]:
+        return
+    else:
+        hca_json_cache[project_uuid][bundle_url] = {}
+    file_type2json_list = get_hca_structure_for_path(hca_files_path, bundle)
+    if not file_type2json_list:
+        err_msg = "Failed to retrieve json content for project: %s and bundle url: %s using path: %s" % (project_uuid, bundle_url, '.'.join(hca_files_path))
+        logger.error(err_msg)
+        raise HCARetrievalError(err_msg)
+    for file_type in file_type2json_list.keys():
+        if re.search(r'\_json$', file_type):
+            schema_type = re.sub(r"\_json$", "", file_type)
+            if re.search(r"" + utils.get_val(config, 'hca_analysis_file_regex'), schema_type):
+                # This is an analysis bundle - don't add it to cache
+                hca_json_cache[project_uuid].pop(bundle_url)
+                break
+            hca_json_cache[project_uuid][bundle_url][schema_type] = []
+            for json_dict in file_type2json_list[file_type]:
+                hca_json_cache[project_uuid][bundle_url][schema_type].append(json_dict)
+                json_files_cnt += 1
+        if violates_hca_schema_assumptions(file_type, hca_json_cache[project_uuid][bundle_url][schema_type], config):
+            logger.warning("File type: %s for project uuid: %s ; bundle url: %s ; violates the assumption that only one json file for that type should exist in a bundle" % (file_type, project_uuid, bundle_url))
+    return json_files_cnt
+
+# Retrieve a list of all accessions corresponding to project uuid - from project_json of one of project_uuid's bundles in hca_json_cache
+def get_gxa_accession_for_project_uuid(project_uuid, config):
+    gxa_accessions = set([])
+    if project_uuid in hca_json_cache:
+        first_bundle_url = list(hca_json_cache[project_uuid].keys())[0]
+        project_json = hca_json_cache[project_uuid][first_bundle_url][utils.get_val(config, 'hca_project')][0]
+        # E-AAAA-00 appears to be the default value HCA uses when no ArrayExpress accession is available
+        hca_old_arrayexpress_label = utils.get_val(config, 'hca_old_arrayexpress_label')
+        hca_new_arrayexpress_label = utils.get_val(config, 'hca_new_arrayexpress_label')
+        if hca_old_arrayexpress_label in project_json.keys():
+            if project_json[hca_old_arrayexpress_label] != 'E-AAAA-00':
+                gxa_accessions.add(project_json[hca_old_arrayexpress_label])
+        elif hca_new_arrayexpress_label in project_json.keys():
+            # For the reason for the loop below see a comment near hca_old_arrayexpress_label in hca2mtab.yml
+            for gxa_accession in project_json[hca_new_arrayexpress_label]:
+                gxa_accessions.add(gxa_accession)
+        hca_supplementary_links_label = utils.get_val(config, 'hca_supplementary_links_label')
+        if hca_supplementary_links_label in project_json.keys():
+            for url in project_json[hca_supplementary_links_label]:
+                m = re.search(r'^.*?\/(E-\w{4}-\d+).*$', url)
+                if m:
+                    gxa_accessions.add(m.group(1))
+        # If HCA project uuid corresponds to multiple existing gxa accessions, we join them into a single label - the decision on how to split them into separate experiments is left to gxa curators
+        if len(gxa_accessions) > 0:
+            return ''.join(gxa_accessions)
+    return None
+
+# Retrieve all HCA json content for project_uuid
+def get_json_for_project_uuid(project_uuid):
+    return hca_json_cache[project_uuid]
+
+# Return True if file_type violates our assumption that there should exist only one json file for tha type in a HCA bundle
+def violates_hca_schema_assumptions(schema_type, json_list, config):
+    if schema_type in utils.get_val(config, 'hca_schemas_with_one_json_per_bundle_expected'):
+        return len(json_list) > 1
+    return False
+
+# Retrieve a dict in hca_data_structure that corresponds to hca_schema_path. If no such dict is found, return an empty dict
+def get_hca_structure_for_path(hca_schema_path, hca_data_structure):
+    struct = hca_data_structure
+    for key in hca_schema_path:
+        if key in struct:
+            struct = struct[key]
+        else:
+            struct = {}
+    return struct
+
+version = '0.1'
+# End of utils.py


### PR DESCRIPTION
… in a new module: hcadam; 2. Now caching all json objects at initial project search/retrieval time (faster than the previous per bundle, one json file retrieval at a time, but requires much more memory); 3. Removed the prototype schema migrations solution - decided to wait for the official implementation in SchemaTemplate library instead; 4. Moved to config the last remaining hard-coded HCA schema fields (protocols and publications)